### PR TITLE
Source field added to infohash

### DIFF
--- a/init.c
+++ b/init.c
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <sys/stat.h>     /* the stat structure */
 #include <unistd.h>       /* getopt(), getcwd(), sysconf() */
 #include <string.h>       /* strcmp(), strlen(), strncpy() */
+#include <stdbool.h>      /* bool: true / false */
 #ifdef USE_LONG_OPTIONS
 #include <getopt.h>       /* getopt_long() */
 #endif
@@ -290,6 +291,7 @@ static void print_help()
 	  "                                default is <name>.torrent\n"
 	  "-p, --private                 : set the private flag\n"
 	  "-s, --source                  : add source string embedded in infohash\n"
+	  "-f, --fast                    : create seperate fast resume torrent for libtorrent\n"
 #ifdef USE_PTHREADS
 	  "-t, --threads=<n>             : use <n> threads for calculating hashes\n"
 	  "                                default is the number of CPU cores\n"
@@ -312,6 +314,8 @@ static void print_help()
 	  "                    default is <name>.torrent\n"
 	  "-p                : set the private flag\n"
 	  "-s                : add source string embedded in infohash\n"
+	  "-f                : create seperate fast resume torrent for libtorrent\n"
+
 #ifdef USE_PTHREADS
 	  "-t <n>            : use <n> threads for calculating hashes\n"
 	  "                    default is the number of CPU cores\n"
@@ -421,6 +425,7 @@ EXPORT void init(metafile_t *m, int argc, char *argv[])
 		{"output", 1, NULL, 'o'},
 		{"private", 0, NULL, 'p'},
 		{"source", 1, NULL, 's'},
+		{"fast", 1, NULL, 'f'},
 #ifdef USE_PTHREADS
 		{"threads", 1, NULL, 't'},
 #endif
@@ -432,9 +437,9 @@ EXPORT void init(metafile_t *m, int argc, char *argv[])
 
 	/* now parse the command line options given */
 #ifdef USE_PTHREADS
-#define OPT_STRING "a:c:dhl:n:o:ps:t:vw:"
+#define OPT_STRING "a:c:dhl:n:o:pfs:t:vw:"
 #else
-#define OPT_STRING "a:c:dhl:n:o:ps:vw:"
+#define OPT_STRING "a:c:dhl:n:o:pfs:vw:"
 #endif
 #ifdef USE_LONG_OPTIONS
 	while ((c = getopt_long(argc, argv, OPT_STRING,
@@ -477,6 +482,9 @@ EXPORT void init(metafile_t *m, int argc, char *argv[])
 			break;
 		case 'o':
 			m->metainfo_file_path = optarg;
+			break;
+		case 'f':
+			m->fast_resume = true;
 			break;
 		case 'p':
 			m->private = 1;
@@ -523,11 +531,11 @@ EXPORT void init(metafile_t *m, int argc, char *argv[])
 	/* user must specify at least one announce URL as it wouldn't make
 	 * any sense to have a default for this.
 	 * it is ok not to have any unless torrent is private. */
-	if (m->announce_list == NULL && m->private == 1) {
+	/*if (m->announce_list == NULL && m->private == 1) {
 		fprintf(stderr, "Must specify an announce URL. "
 			"Use -h for help.\n");
 		exit(EXIT_FAILURE);
-	}
+	}*/
 	if (announce_last != NULL)
 		announce_last->next = NULL;
 

--- a/init.c
+++ b/init.c
@@ -520,6 +520,14 @@ EXPORT void init(metafile_t *m, int argc, char *argv[])
 	}
 	m->piece_length = 1 << m->piece_length;
 
+	/* user must specify at least one announce URL as it wouldn't make
+	 * any sense to have a default for this.
+	 * it is ok not to have any unless torrent is private. */
+	if (m->announce_list == NULL && m->private == 1) {
+		fprintf(stderr, "Must specify an announce URL. "
+			"Use -h for help.\n");
+		exit(EXIT_FAILURE);
+	}
 	if (announce_last != NULL)
 		announce_last->next = NULL;
 

--- a/init.c
+++ b/init.c
@@ -510,14 +510,6 @@ EXPORT void init(metafile_t *m, int argc, char *argv[])
 	}
 	m->piece_length = 1 << m->piece_length;
 
-	/* user must specify at least one announce URL as it wouldn't make
-	 * any sense to have a default for this.
-	 * it is ok not to have any unless torrent is private. */
-	if (m->announce_list == NULL && m->private == 1) {
-		fprintf(stderr, "Must specify an announce URL. "
-			"Use -h for help.\n");
-		exit(EXIT_FAILURE);
-	}
 	if (announce_last != NULL)
 		announce_last->next = NULL;
 

--- a/init.c
+++ b/init.c
@@ -289,6 +289,7 @@ static void print_help()
 	  "-o, --output=<filename>       : set the path and filename of the created file\n"
 	  "                                default is <name>.torrent\n"
 	  "-p, --private                 : set the private flag\n"
+	  "-s, --source                  : add source string embedded in infohash\n"
 #ifdef USE_PTHREADS
 	  "-t, --threads=<n>             : use <n> threads for calculating hashes\n"
 	  "                                default is the number of CPU cores\n"
@@ -310,6 +311,7 @@ static void print_help()
 	  "-o <filename>     : set the path and filename of the created file\n"
 	  "                    default is <name>.torrent\n"
 	  "-p                : set the private flag\n"
+	  "-s                : add source string embedded in infohash\n"
 #ifdef USE_PTHREADS
 	  "-t <n>            : use <n> threads for calculating hashes\n"
 	  "                    default is the number of CPU cores\n"
@@ -386,6 +388,10 @@ static void dump_options(metafile_t *m)
 
 	print_web_seed_list(m->web_seed_list);
 
+	/* Print source string only if set */
+	if (m->source)
+		printf("\n Source:      %s\n\n", m->source);
+
 	printf("  Comment:      ");
 	if (m->comment == NULL)
 		printf("none\n\n");
@@ -414,6 +420,7 @@ EXPORT void init(metafile_t *m, int argc, char *argv[])
 		{"name", 1, NULL, 'n'},
 		{"output", 1, NULL, 'o'},
 		{"private", 0, NULL, 'p'},
+		{"source", 1, NULL, 's'},
 #ifdef USE_PTHREADS
 		{"threads", 1, NULL, 't'},
 #endif
@@ -425,9 +432,9 @@ EXPORT void init(metafile_t *m, int argc, char *argv[])
 
 	/* now parse the command line options given */
 #ifdef USE_PTHREADS
-#define OPT_STRING "a:c:dhl:n:o:pt:vw:"
+#define OPT_STRING "a:c:dhl:n:o:ps:t:vw:"
 #else
-#define OPT_STRING "a:c:dhl:n:o:pvw:"
+#define OPT_STRING "a:c:dhl:n:o:ps:vw:"
 #endif
 #ifdef USE_LONG_OPTIONS
 	while ((c = getopt_long(argc, argv, OPT_STRING,
@@ -473,6 +480,9 @@ EXPORT void init(metafile_t *m, int argc, char *argv[])
 			break;
 		case 'p':
 			m->private = 1;
+			break;
+		case 's':
+			m->source = optarg;
 			break;
 #ifdef USE_PTHREADS
 		case 't':

--- a/main.c
+++ b/main.c
@@ -144,6 +144,7 @@ int main(int argc, char *argv[])
 		0,    /* target_is_directory  */
 		0,    /* no_creation_date */
 		0,    /* private */
+		NULL, /* source string */
 		0,    /* verbose */
 #ifdef USE_PTHREADS
 		0,    /* threads, initialised by init() */

--- a/mktorrent.h
+++ b/mktorrent.h
@@ -41,6 +41,7 @@ typedef struct {
 	char *comment;             /* optional comment */
 	const char *torrent_name;  /* name of torrent (name of directory) */
 	char *metainfo_file_path;  /* absolute path to the metainfo file */
+	_Bool fast_resume;          /* output seperate fast resume torrent */
 	slist_t *web_seed_list;    /* web seed URLs */
 	int target_is_directory;   /* target is a directory */
 	int no_creation_date;      /* don't write the creation date */

--- a/mktorrent.h
+++ b/mktorrent.h
@@ -45,6 +45,7 @@ typedef struct {
 	int target_is_directory;   /* target is a directory */
 	int no_creation_date;      /* don't write the creation date */
 	int private;               /* set the private flag */
+	char *source;              /* set source for private trackers */
 	int verbose;               /* be verbose */
 #ifdef USE_PTHREADS
 	unsigned int threads;      /* number of threads used for hashing */

--- a/output.c
+++ b/output.c
@@ -166,6 +166,9 @@ EXPORT void write_metainfo(FILE *f, metafile_t *m, unsigned char *hash_string)
 	if (m->private)
 		fprintf(f, "7:privatei1e");
 
+	if (m->source)
+		fprintf(f, "6:source%lu:%s", (unsigned long)strlen(m->source), m->source);
+
 	/* end the info section */
 	fprintf(f, "e");
 

--- a/output.c
+++ b/output.c
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <stdio.h>        /* printf() etc. */
 #include <string.h>       /* strlen() etc. */
 #include <time.h>         /* time() */
+#include <stdbool.h>      /* bool: true / false */
 #ifdef USE_OPENSSL
 #include <openssl/sha.h>  /* SHA_DIGEST_LENGTH */
 #else
@@ -113,7 +114,7 @@ static void write_web_seed_list(FILE *f, slist_t *list)
  * write metainfo to the file stream using all the information
  * we've gathered so far and the hash string calculated
  */
-EXPORT void write_metainfo(FILE *f, metafile_t *m, unsigned char *hash_string)
+EXPORT void write_metainfo(FILE *f, metafile_t *m, unsigned char *hash_string, bool fast)
 {
 	/* let the user know we've started writing the metainfo file */
 	printf("Writing metainfo file... ");
@@ -165,12 +166,19 @@ EXPORT void write_metainfo(FILE *f, metafile_t *m, unsigned char *hash_string)
 	/* set the private flag */
 	if (m->private)
 		fprintf(f, "7:privatei1e");
-
+	
+	/* write source info to file if present */
 	if (m->source)
 		fprintf(f, "6:source%lu:%s", (unsigned long)strlen(m->source), m->source);
 
 	/* end the info section */
 	fprintf(f, "e");
+
+	/* write fast libtorrent data */
+	if (fast) {
+		fprintf(f, "17:libtorrent_resumed8:bitfieldi%ie5:filesld9:completedi%ie5:mtimei%lde8:priorityi1eeee",
+			m->pieces, m->pieces, (long)time(NULL));
+	}
 
 	/* add url-list if one is specified */
 	if (m->web_seed_list != NULL) {


### PR DESCRIPTION
Added source string to info hash area to make it possible to generate infohash accurate torrent files for private trackeres. This is beneficial because you won't need to redownload the torrent to start seeding if you added your appropriate announce and the source tag to make it accurate with their unique info hash.

![Private tracker using source string](https://i.imgur.com/dZRnY14.png)

![another one](https://i.imgur.com/uk5F72V.png)
