### PR TITLE
"at least one is required" announce help removed from short options

### DIFF
--- a/init.c
+++ b/init.c
@@ -300,7 +300,6 @@ static void print_help()
 	  "                                additional -w adds more URLs\n"
 #else
 	  "-a <url>[,<url>]* : specify the full announce URLs\n"
-	  "                    at least one is required\n"
 	  "                    additional -a adds backup trackers\n"
 	  "-c <comment>      : add a comment to the metainfo\n"
 	  "-d                : don't write the creation date\n"


### PR DESCRIPTION
A few commits ago, the text "at least one is required" for the announce URL got removed from the long options help screen (#26 & 5c950787bf5aabb1f73be15a0dd29c270bb6adf4), but the short options help screen remains unchanged.