### PR TITLE
implement quicksort for faster file path sorting

### DIFF
--- a/mktorrent.h
+++ b/mktorrent.h
@@ -54,6 +54,7 @@ typedef struct {
 	/* information calculated by read_dir() */
 	int64_t size;                /* combined size of all files */
 	flist_t *file_list;        /* list of files and their sizes */
+	int64_t file_count;        /* count of total files */
 	unsigned int pieces;       /* number of pieces */
 } metafile_t;
 


### PR DESCRIPTION
I am creating a torrent with around 2 million files and the insertion sort in `init()` absolutely murders performance, just walking the files took almost 24 hours. I changed it to just prepend each file and sort at the end with quicksort and walking the files now takes about 5 minutes.