### PR TITLE
C99 and POSIX compliant identifier names

### DIFF
--- a/ftw.h
+++ b/ftw.h
@@ -1,5 +1,5 @@
-#ifndef _FTW_H
-#define _FTW_H
+#ifndef MKTORRENT_FTW_H
+#define MKTORRENT_FTW_H
 
 typedef int (*file_tree_walk_cb)(const char *name,
 		const struct stat *sbuf, void *data);
@@ -10,4 +10,4 @@ int file_tree_walk(const char *dirname, unsigned int nfds,
 
 #endif /* ALLINONE */
 
-#endif /* _FTW_H */
+#endif /* MKTORRENT_FTW_H */

--- a/hash.c
+++ b/hash.c
@@ -53,7 +53,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
  * concatenation of the (20 byte) SHA1 hash of every piece
  * last piece may be shorter
  */
-EXPORT unsigned char *make_hash(metafile_t *m)
+EXPORT unsigned char *make_hash(struct metafile *m)
 {
 	flist_t *f;                     /* pointer to a place in the file list */
 	unsigned char *hash_string;     /* the hash string */

--- a/init.c
+++ b/init.c
@@ -67,7 +67,7 @@ static const char *basename(const char *s)
 	return r;
 }
 
-static void set_absolute_file_path(metafile_t *m)
+static void set_absolute_file_path(struct metafile *m)
 {
 	char *string;		/* string to return */
 	size_t length = 32;	/* length of the string */
@@ -173,7 +173,7 @@ static slist_t *get_slist(char *s)
  * checks if target is a directory
  * sets the file_list and size if it isn't
  */
-static int is_dir(metafile_t *m, char *target)
+static int is_dir(struct metafile *m, char *target)
 {
 	struct stat s;		/* stat structure for stat() to fill */
 
@@ -222,7 +222,7 @@ static int process_node(const char *path, const struct stat *sb, void *data)
 {
 	flist_t **p;            /* pointer to a node in the file list */
 	flist_t *new_node;      /* place to store a newly created node */
-	metafile_t *m = data;
+	struct metafile *m = data;
 
 	/* skip non-regular files */
 	if (!S_ISREG(sb->st_mode))
@@ -361,7 +361,7 @@ static void print_web_seed_list(slist_t *list)
 /*
  * print out all the options
  */
-static void dump_options(metafile_t *m)
+static void dump_options(struct metafile *m)
 {
 	printf("Options:\n"
 	       "  Announce URLs:\n");
@@ -405,7 +405,7 @@ static void dump_options(metafile_t *m)
  * and fill out the appropriate fields of the
  * metafile structure
  */
-EXPORT void init(metafile_t *m, int argc, char *argv[])
+EXPORT void init(struct metafile *m, int argc, char *argv[])
 {
 	int c;			/* return value of getopt() */
 	llist_t *announce_last = NULL;

--- a/main.c
+++ b/main.c
@@ -70,11 +70,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "output.c"
 #else /* ALLINONE */
 /* init.c */
-extern void init(metafile_t *m, int argc, char *argv[]);
+extern void init(struct metafile *m, int argc, char *argv[]);
 /* hash.c */
-extern unsigned char *make_hash(metafile_t *m);
+extern unsigned char *make_hash(struct metafile *m);
 /* output.c */
-extern void write_metainfo(FILE *f, metafile_t *m, unsigned char *hash_string);
+extern void write_metainfo(FILE *f, struct metafile *m, unsigned char *hash_string);
 #endif /* ALLINONE */
 
 #ifndef O_BINARY
@@ -136,7 +136,7 @@ static void close_file(FILE *f)
 int main(int argc, char *argv[])
 {
 	FILE *file;	/* stream for writing to the metainfo file */
-	metafile_t m = {
+	struct metafile m = {
 		/* options */
 		18,   /* piece_length, 2^18 = 256kb by default */
 		NULL, /* announce_list */

--- a/mktorrent.h
+++ b/mktorrent.h
@@ -1,5 +1,5 @@
-#ifndef _MKTORRENT_H
-#define _MKTORRENT_H
+#ifndef MKTORRENT_MKTORRENT_H
+#define MKTORRENT_MKTORRENT_H
 
 #ifdef _WIN32
 #define DIRSEP      "\\"
@@ -34,7 +34,7 @@ struct flist_s {
 	flist_t *next;
 };
 
-typedef struct {
+struct metafile {
 	/* options */
 	unsigned int piece_length; /* piece length */
 	llist_t *announce_list;    /* announce URLs */
@@ -55,6 +55,6 @@ typedef struct {
 	int64_t size;                /* combined size of all files */
 	flist_t *file_list;        /* list of files and their sizes */
 	unsigned int pieces;       /* number of pieces */
-} metafile_t;
+};
 
-#endif /* _MKTORRENT_H */
+#endif /* MKTORRENT_MKTORRENT_H */

--- a/output.c
+++ b/output.c
@@ -113,7 +113,7 @@ static void write_web_seed_list(FILE *f, slist_t *list)
  * write metainfo to the file stream using all the information
  * we've gathered so far and the hash string calculated
  */
-EXPORT void write_metainfo(FILE *f, metafile_t *m, unsigned char *hash_string)
+EXPORT void write_metainfo(FILE *f, struct metafile *m, unsigned char *hash_string)
 {
 	/* let the user know we've started writing the metainfo file */
 	printf("Writing metainfo file... ");

--- a/sha1.h
+++ b/sha1.h
@@ -1,8 +1,8 @@
 /* Public API for Steve Reid's public domain SHA-1 implementation */
 /* This file is in the public domain */
 
-#ifndef __SHA1_H
-#define __SHA1_H
+#ifndef MKTORRENT_SHA1_H
+#define MKTORRENT_SHA1_H
 
 typedef struct {
     uint32_t state[5];
@@ -18,4 +18,4 @@ void SHA1_Update(SHA_CTX *context, const uint8_t *data, unsigned long len);
 void SHA1_Final(uint8_t *digest, SHA_CTX *context);
 #endif
 
-#endif /* __SHA1_H */
+#endif /* MKTORRENT_SHA1_H */


### PR DESCRIPTION
This commit changes the names of some identifiers to conform to ISO C99 and POSIX standards. The names `slist_t`, `llist_t`, and `flist_t` have not been changed because I plan to replace them with a general purpose linked list implementation in the near future.