### PR TITLE
#include changes and header files for multiple source files

### DIFF
--- a/export.h
+++ b/export.h
@@ -1,0 +1,10 @@
+#ifndef MKTORRENT_EXPORT_H
+#define MKTORRENT_EXPORT_H
+
+#ifdef ALLINONE
+#define EXPORT static
+#else
+#define EXPORT
+#endif /* ALLINONE */
+
+#endif /* MKTORRENT_EXPORT_H */

--- a/ftw.c
+++ b/ftw.c
@@ -16,7 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 */
-#ifndef ALLINONE
+
+
 #include <stdlib.h>
 #include <errno.h>
 #include <string.h>
@@ -26,16 +27,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <unistd.h>
 #include <dirent.h>
 
-#ifdef _WIN32
-#define DIRSEP_CHAR '\\'
-#else
-#define DIRSEP_CHAR '/'
-#endif /* _WIN32 */
-
-#define EXPORT
-#endif /* ALLINONE */
-
+#include "export.h"
+#include "mktorrent.h" /* DIRSEP_CHAR */
 #include "ftw.h"
+
 
 struct dir_state {
 	struct dir_state *next;

--- a/ftw.h
+++ b/ftw.h
@@ -1,13 +1,13 @@
 #ifndef MKTORRENT_FTW_H
 #define MKTORRENT_FTW_H
 
+#include "export.h"
+
 typedef int (*file_tree_walk_cb)(const char *name,
 		const struct stat *sbuf, void *data);
 
-#ifndef ALLINONE
-int file_tree_walk(const char *dirname, unsigned int nfds,
+EXPORT int file_tree_walk(const char *dirname, unsigned int nfds,
 		file_tree_walk_cb callback, void *data);
 
-#endif /* ALLINONE */
 
 #endif /* MKTORRENT_FTW_H */

--- a/hash.c
+++ b/hash.c
@@ -16,9 +16,9 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 */
-#ifndef ALLINONE
+
+
 #include <stdlib.h>       /* exit() */
-#include <sys/types.h>    /* off_t */
 #include <errno.h>        /* errno */
 #include <string.h>       /* strerror() */
 #include <stdio.h>        /* printf() etc. */
@@ -32,10 +32,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "sha1.h"
 #endif
 
+#include "export.h"
 #include "mktorrent.h"
-
-#define EXPORT
-#endif /* ALLINONE */
+#include "hash.h"
 
 #ifndef O_BINARY
 #define O_BINARY 0
@@ -46,6 +45,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #else
 #define OPENFLAGS (O_RDONLY | O_BINARY)
 #endif
+
 
 /*
  * go through the files in file_list, split their contents into pieces

--- a/hash.h
+++ b/hash.h
@@ -1,0 +1,9 @@
+#ifndef MKTORRENT_HASH_H
+#define MKTORRENT_HASH_H
+
+#include "export.h"    /* EXPORT */
+#include "mktorrent.h" /* struct metafile */
+
+EXPORT unsigned char *make_hash(struct metafile *m);
+
+#endif /* MKTORRENT_HASH_H */

--- a/hash_pthreads.c
+++ b/hash_pthreads.c
@@ -16,28 +16,27 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 */
-#ifndef ALLINONE
-#include <stdlib.h>      /* exit(), malloc() */
-#include <sys/types.h>   /* off_t */
-#include <errno.h>       /* errno */
-#include <string.h>      /* strerror() */
-#include <stdio.h>       /* printf() etc. */
-#include <fcntl.h>       /* open() */
-#include <unistd.h>      /* access(), read(), close() */
-#include <inttypes.h>    /* PRId64 etc. */
+
+
+#include <stdlib.h>       /* exit(), malloc() */
+#include <sys/types.h>    /* off_t */
+#include <errno.h>        /* errno */
+#include <string.h>       /* strerror() */
+#include <stdio.h>        /* printf() etc. */
+#include <fcntl.h>        /* open() */
+#include <unistd.h>       /* read(), close() */
+#include <inttypes.h>     /* PRId64 etc. */
+#include <pthread.h>
 
 #ifdef USE_OPENSSL
-#include <openssl/sha.h> /* SHA1() */
+#include <openssl/sha.h>  /* SHA1() */
 #else
 #include "sha1.h"
 #endif
-#include <pthread.h>     /* pthread functions and data structures */
 
+#include "export.h"
 #include "mktorrent.h"
-
-#define EXPORT
-#endif /* ALLINONE */
-
+#include "hash.h"
 
 #ifndef PROGRESS_PERIOD
 #define PROGRESS_PERIOD 200000
@@ -52,6 +51,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #else
 #define OPENFLAGS (O_RDONLY | O_BINARY)
 #endif
+
 
 struct piece {
 	struct piece *next;

--- a/init.c
+++ b/init.c
@@ -16,7 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 */
-#ifndef ALLINONE
+
+
 #include <stdlib.h>       /* exit() */
 #include <sys/types.h>    /* off_t */
 #include <errno.h>        /* errno */
@@ -27,20 +28,20 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <string.h>       /* strcmp(), strlen(), strncpy() */
 #include <strings.h>      /* strcasecmp() */
 #include <inttypes.h>     /* PRId64 etc. */
+
 #ifdef USE_LONG_OPTIONS
 #include <getopt.h>       /* getopt_long() */
 #endif
 
+#include "export.h"
 #include "mktorrent.h"
 #include "ftw.h"
-
-#define EXPORT
-#endif /* ALLINONE */
 
 #ifndef MAX_OPENFD
 #define MAX_OPENFD 100	/* Maximum number of file descriptors
 			   file_tree_walk() will open */
 #endif
+
 
 static void strip_ending_dirseps(char *s)
 {

--- a/init.h
+++ b/init.h
@@ -1,0 +1,9 @@
+#ifndef MKTORRENT_INIT_H
+#define MKTORRENT_INIT_H
+
+#include "export.h"    /* EXPORT */
+#include "mktorrent.h" /* struct metafile */
+
+EXPORT void init(struct metafile *m, int argc, char *argv[]);
+
+#endif /* MKTORRENT_INIT_H */

--- a/main.c
+++ b/main.c
@@ -17,49 +17,24 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 */
 
+
 #include <stdlib.h>      /* exit() */
-#include <sys/types.h>   /* off_t */
 #include <errno.h>       /* errno */
 #include <string.h>      /* strerror() */
 #include <stdio.h>       /* printf() etc. */
 #include <sys/stat.h>    /* S_IRUSR, S_IWUSR, S_IRGRP, S_IROTH */
 #include <fcntl.h>       /* open() */
 
-#ifdef ALLINONE
-#include <sys/stat.h>
-#include <unistd.h>      /* access(), read(), close(), getcwd(), sysconf() */
-#include <strings.h>     /* strcasecmp() */
-#include <inttypes.h>    /* PRId64 etc. */
-#include <ctype.h>       /* isdigit */
-#ifdef USE_LONG_OPTIONS
-#include <getopt.h>      /* getopt_long() */
-#endif
-#include <time.h>        /* time() */
-#include <dirent.h>      /* opendir(), closedir(), readdir() etc. */
-#ifdef USE_OPENSSL
-#include <openssl/sha.h> /* SHA1(), SHA_DIGEST_LENGTH */
-#else
-#include <inttypes.h>
-#endif
-#ifdef USE_PTHREADS
-#include <pthread.h>     /* pthread functions and data structures */
-#endif
-
-#define EXPORT static
-#else  /* ALLINONE */
-
-#define EXPORT
-#endif /* ALLINONE */
-
+#include "export.h"
 #include "mktorrent.h"
+#include "init.h"
+#include "hash.h"
+#include "output.h"
 
 #ifdef ALLINONE
-#include "ftw.c"
-#include "init.c"
+/* include all .c files in alphabetical order */
 
-#ifndef USE_OPENSSL
-#include "sha1.c"
-#endif
+#include "ftw.c"
 
 #ifdef USE_PTHREADS
 #include "hash_pthreads.c"
@@ -67,14 +42,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "hash.c"
 #endif
 
+#include "init.c"
 #include "output.c"
-#else /* ALLINONE */
-/* init.c */
-extern void init(struct metafile *m, int argc, char *argv[]);
-/* hash.c */
-extern unsigned char *make_hash(struct metafile *m);
-/* output.c */
-extern void write_metainfo(FILE *f, struct metafile *m, unsigned char *hash_string);
+
+#ifndef USE_OPENSSL
+#include "sha1.c"
+#endif
+
 #endif /* ALLINONE */
 
 #ifndef O_BINARY
@@ -84,9 +58,11 @@ extern void write_metainfo(FILE *f, struct metafile *m, unsigned char *hash_stri
 #ifndef S_IRGRP
 #define S_IRGRP 0
 #endif
+
 #ifndef S_IROTH
 #define S_IROTH 0
 #endif
+
 
 /*
  * create and open the metainfo file for writing and create a stream for it

--- a/output.c
+++ b/output.c
@@ -16,22 +16,23 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 */
-#ifndef ALLINONE
+
+
 #include <sys/types.h>    /* off_t */
-#include <stdio.h>        /* printf() etc. */
+#include <stdio.h>        /* fprintf() etc. */
 #include <string.h>       /* strlen() etc. */
 #include <time.h>         /* time() */
+
 #ifdef USE_OPENSSL
 #include <openssl/sha.h>  /* SHA_DIGEST_LENGTH */
 #else
-#include <inttypes.h>
 #include "sha1.h"
 #endif
 
-#include "mktorrent.h"
+#include "export.h"       /* EXPORT */
+#include "mktorrent.h"    /* struct metafile */
+#include "output.h"
 
-#define EXPORT
-#endif /* ALLINONE */
 
 /*
  * write announce list

--- a/output.h
+++ b/output.h
@@ -1,0 +1,12 @@
+#ifndef MKTORRENT_OUTPUT_H
+#define MKTORRENT_OUTPUT_H
+
+#include <stdio.h>      /* FILE */
+
+#include "export.h"     /* EXPORT */
+#include "mktorrent.h"  /* struct metafile */
+
+EXPORT void write_metainfo(FILE *f, struct metafile *m,
+			unsigned char *hash_string);
+
+#endif /* MKTORRENT_OUTPUT_H */

--- a/sha1.c
+++ b/sha1.c
@@ -16,16 +16,16 @@
 /* #define SHA1_WIPE_VARS */
 /* #define SHA1_VERBOSE */
 
-#ifndef ALLINONE
+
 #ifdef SHA1_TEST
 #include <stdio.h>
 #endif
+
 #include <string.h>
+#include <stdint.h>
 #include <inttypes.h>
 
-#define EXPORT
-#endif /* ALLINONE */
-
+#include "export.h"
 #include "sha1.h"
 
 #define rol(value, bits) (((value) << (bits)) | ((value) >> (32 - (bits))))

--- a/sha1.h
+++ b/sha1.h
@@ -1,8 +1,13 @@
 /* Public API for Steve Reid's public domain SHA-1 implementation */
 /* This file is in the public domain */
 
+
 #ifndef MKTORRENT_SHA1_H
 #define MKTORRENT_SHA1_H
+
+#include <stdint.h>  /* uintX_t */
+
+#include "export.h"  /* EXPORT */
 
 typedef struct {
     uint32_t state[5];
@@ -12,10 +17,9 @@ typedef struct {
 
 #define SHA_DIGEST_LENGTH 20
 
-#ifndef ALLINONE
-void SHA1_Init(SHA_CTX *context);
-void SHA1_Update(SHA_CTX *context, const uint8_t *data, unsigned long len);
-void SHA1_Final(uint8_t *digest, SHA_CTX *context);
-#endif
+
+EXPORT void SHA1_Init(SHA_CTX *context);
+EXPORT void SHA1_Update(SHA_CTX *context, const uint8_t *data, unsigned long len);
+EXPORT void SHA1_Final(uint8_t *digest, SHA_CTX *context);
 
 #endif /* MKTORRENT_SHA1_H */


### PR DESCRIPTION
This commit changes how files are included when ALLINONE is defined to make extending this functionality to new source files easier. A new `export.h` has been created to enable easier use of the `EXPORT` macro. Furthermore, header files have been created for `init.c`, `output.c`, and the hashing related source files.