### PR TITLE
Fix signedness issue

### DIFF
--- a/BSDmakefile
+++ b/BSDmakefile
@@ -18,7 +18,7 @@
 .include "Makefile"
 
 CC      ?= cc
-CFLAGS  ?= -O2 -Wall
+CFLAGS  ?= -O2 -Wall -Wextra -Wpedantic
 INSTALL ?= install
 PREFIX  ?= /usr/local
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,7 @@
 include Makefile
 
 CC      ?= cc
-CFLAGS  ?= -O2 -Wall
+CFLAGS  ?= -O2 -Wall -Wextra -Wpedantic
 INSTALL ?= install
 PREFIX  ?= /usr/local
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 
 # Default settings shown
 #CC      = cc
-#CFLAGS  = -O2 -Wall
+#CFLAGS  = -O2 -Wall -Wextra -Wpedantic
 #LDFLAGS =
 #INSTALL = install
 #PREFIX  = /usr/local

--- a/init.c
+++ b/init.c
@@ -371,7 +371,7 @@ static void dump_options(struct metafile *m)
 	       "  Metafile:     %s\n"
 	       "  Piece length: %u\n"
 #ifdef USE_PTHREADS
-	       "  Threads:      %u\n"
+	       "  Threads:      %ld\n"
 #endif
 	       "  Be verbose:   yes\n",
 	       m->torrent_name, m->metainfo_file_path, m->piece_length
@@ -541,7 +541,7 @@ EXPORT void init(struct metafile *m, int argc, char *argv[])
 	} else {
 #ifdef _SC_NPROCESSORS_ONLN
 		m->threads = sysconf(_SC_NPROCESSORS_ONLN);
-		if (m->threads == -1)
+		if (m->threads < 0)
 #endif
 			m->threads = 2; /* some sane default */
 	}

--- a/init.c
+++ b/init.c
@@ -541,7 +541,7 @@ EXPORT void init(struct metafile *m, int argc, char *argv[])
 	} else {
 #ifdef _SC_NPROCESSORS_ONLN
 		m->threads = sysconf(_SC_NPROCESSORS_ONLN);
-		if (m->threads < 0)
+		if (m->threads <= 0)
 #endif
 			m->threads = 2; /* some sane default */
 	}

--- a/mktorrent.h
+++ b/mktorrent.h
@@ -48,7 +48,7 @@ struct metafile {
 	char *source;              /* set source for private trackers */
 	int verbose;               /* be verbose */
 #ifdef USE_PTHREADS
-	unsigned int threads;      /* number of threads used for hashing */
+	long threads;              /* number of threads used for hashing */
 #endif
 
 	/* information calculated by read_dir() */


### PR DESCRIPTION
This pull request changes the type of `struct metafile.threads` to `long` from `unsigned int` to handle possible negative values returned by `sysconf(3)`. Furthermore, `-Wextra` and `-Wpedantic` have been added to the makefiles to catch such issues in the future.