### PR TITLE
Utility function for handling fatal errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,4 +66,4 @@ program = mktorrent
 version = 1.1
 
 HEADERS  = mktorrent.h
-SRCS     = ftw.c init.c sha1.c hash.c output.c main.c
+SRCS     = ftw.c init.c sha1.c hash.c output.c main.c msg.c

--- a/ftw.c
+++ b/ftw.c
@@ -46,7 +46,7 @@ static struct dir_state *dir_state_new(struct dir_state *prev,
 	struct dir_state *ds = malloc(sizeof(struct dir_state));
 
 	if (ds == NULL) {
-		fprintf(stderr, "Out of memory.\n");
+		fprintf(stderr, "fatal error: out of memory\n");
 		return NULL;
 	}
 
@@ -61,7 +61,7 @@ static unsigned int dir_state_open(struct dir_state *ds, const char *name,
 {
 	ds->dir = opendir(name);
 	if (ds->dir == NULL) {
-		fprintf(stderr, "Error opening '%s': %s\n",
+		fprintf(stderr, "fatal error: cannot open '%s': %s\n",
 				name, strerror(errno));
 		return 1;
 	}
@@ -76,7 +76,7 @@ static unsigned int dir_state_reopen(struct dir_state *ds, char *name)
 	name[ds->length] = '\0';
 	ds->dir = opendir(name);
 	if (ds->dir == NULL) {
-		fprintf(stderr, "Error opening '%s': %s\n",
+		fprintf(stderr, "fatal error: cannot open '%s': %s\n",
 				name, strerror(errno));
 		return 1;
 	}
@@ -92,13 +92,13 @@ static unsigned int dir_state_close(struct dir_state *ds)
 {
 	ds->offset = telldir(ds->dir);
 	if (ds->offset < 0) {
-		fprintf(stderr, "Error getting dir offset: %s\n",
+		fprintf(stderr, "fatal error: cannot obtain dir offset: %s\n",
 				strerror(errno));
 		return 1;
 	}
 
 	if (closedir(ds->dir)) {
-		fprintf(stderr, "Error closing directory: %s\n",
+		fprintf(stderr, "fatal error: cannot close directory: %s\n",
 				strerror(errno));
 		return 1;
 	}
@@ -141,7 +141,7 @@ EXPORT int file_tree_walk(const char *dirname, unsigned int nfds,
 
 	path = malloc(path_size);
 	if (path == NULL) {
-		fprintf(stderr, "Out of memory.\n");
+		fprintf(stderr, "fatal error: out of memory\n");
 		return cleanup(ds, NULL, -1);
 	}
 	path_max = path + path_size;
@@ -156,7 +156,7 @@ EXPORT int file_tree_walk(const char *dirname, unsigned int nfds,
 
 			new_path = realloc(path, 2*path_size);
 			if (new_path == NULL) {
-				fprintf(stderr, "Out of memory.\n");
+				fprintf(stderr, "fatal error: out of memory\n");
 				return cleanup(ds, path, -1);
 			}
 			end = new_path + path_size;
@@ -205,7 +205,7 @@ EXPORT int file_tree_walk(const char *dirname, unsigned int nfds,
 
 					new_path = realloc(path, 2*path_size);
 					if (new_path == NULL) {
-						fprintf(stderr, "Out of memory.\n");
+						fprintf(stderr, "fatal error: out of memory\n");
 						return cleanup(ds, path, -1);
 					}
 					end = new_path + path_size;
@@ -216,7 +216,7 @@ EXPORT int file_tree_walk(const char *dirname, unsigned int nfds,
 			}
 
 			if (stat(path, &sbuf)) {
-				fprintf(stderr, "Error stat'ing '%s': %s\n",
+				fprintf(stderr, "fatal error: cannot stat '%s': %s\n",
 						path, strerror(errno));
 				return cleanup(ds, path, -1);
 			}
@@ -249,7 +249,7 @@ EXPORT int file_tree_walk(const char *dirname, unsigned int nfds,
 		} else {
 			if (closedir(ds->dir)) {
 				path[ds->length] = '\0';
-				fprintf(stderr, "Error closing '%s': %s\n",
+				fprintf(stderr, "fatal error: cannot close '%s': %s\n",
 					path, strerror(errno));
 				return cleanup(ds, path, -1);
 			}

--- a/hash.c
+++ b/hash.c
@@ -35,6 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "export.h"
 #include "mktorrent.h"
 #include "hash.h"
+#include "msg.h"
 
 #ifndef O_BINARY
 #define O_BINARY 0
@@ -75,10 +76,7 @@ EXPORT unsigned char *make_hash(struct metafile *m)
 	read_buf = malloc(m->piece_length);
 
 	/* check if we've run out of memory */
-	if (hash_string == NULL || read_buf == NULL) {
-		fprintf(stderr, "Out of memory.\n");
-		exit(EXIT_FAILURE);
-	}
+	FATAL_IF0(hash_string == NULL || read_buf == NULL, "Out of memory.\n");
 
 	/* initiate pos to point to the beginning of hash_string */
 	pos = hash_string;
@@ -88,11 +86,8 @@ EXPORT unsigned char *make_hash(struct metafile *m)
 	for (f = m->file_list; f; f = f->next) {
 
 		/* open the current file for reading */
-		if ((fd = open(f->path, OPENFLAGS)) == -1) {
-			fprintf(stderr, "Error opening '%s' for reading: %s\n",
-					f->path, strerror(errno));
-			exit(EXIT_FAILURE);
-		}
+		FATAL_IF((fd = open(f->path, OPENFLAGS)) == -1,
+			"Error opening '%s' for reading: %s\n",	f->path, strerror(errno));
 		printf("Hashing %s.\n", f->path);
 		fflush(stdout);
 
@@ -102,12 +97,8 @@ EXPORT unsigned char *make_hash(struct metafile *m)
 		   to the end of the file */
 		while (1) {
 			ssize_t d = read(fd, read_buf + r, m->piece_length - r);
-
-			if (d < 0) {
-				fprintf(stderr, "Error reading from '%s': %s\n",
-						f->path, strerror(errno));
-				exit(EXIT_FAILURE);
-			}
+			FATAL_IF(d < 0, "Error reading from '%s': %s\n",
+				f->path, strerror(errno));
 
 			if (d == 0) /* end of file */
 				break;
@@ -127,11 +118,8 @@ EXPORT unsigned char *make_hash(struct metafile *m)
 		}
 
 		/* now close the file */
-		if (close(fd)) {
-			fprintf(stderr, "Error closing '%s': %s\n",
-					f->path, strerror(errno));
-			exit(EXIT_FAILURE);
-		}
+		FATAL_IF(close(fd), "Error closing '%s': %s\n",
+			f->path, strerror(errno));
 	}
 
 	/* finally append the hash of the last irregular piece to the hash string */
@@ -143,12 +131,10 @@ EXPORT unsigned char *make_hash(struct metafile *m)
 
 #ifndef NO_HASH_CHECK
 	counter += r;
-	if (counter != m->size) {
-		fprintf(stderr, "Counted %" PRId64 " bytes, "
-				"but hashed %" PRId64 " bytes. "
-				"Something is wrong...\n", m->size, counter);
-		exit(EXIT_FAILURE);
-	}
+	FATAL_IF(counter != m->size,
+		"Counted %" PRId64 " bytes, but hashed %" PRId64 " bytes. "
+		"Something is wrong...\n",
+			m->size, counter);
 #endif
 
 	/* free the read buffer before we return */

--- a/hash.c
+++ b/hash.c
@@ -76,7 +76,7 @@ EXPORT unsigned char *make_hash(struct metafile *m)
 	read_buf = malloc(m->piece_length);
 
 	/* check if we've run out of memory */
-	FATAL_IF0(hash_string == NULL || read_buf == NULL, "Out of memory.\n");
+	FATAL_IF0(hash_string == NULL || read_buf == NULL, "out of memory\n");
 
 	/* initiate pos to point to the beginning of hash_string */
 	pos = hash_string;
@@ -87,7 +87,7 @@ EXPORT unsigned char *make_hash(struct metafile *m)
 
 		/* open the current file for reading */
 		FATAL_IF((fd = open(f->path, OPENFLAGS)) == -1,
-			"Error opening '%s' for reading: %s\n",	f->path, strerror(errno));
+			"cannot open '%s' for reading: %s\n", f->path, strerror(errno));
 		printf("Hashing %s.\n", f->path);
 		fflush(stdout);
 
@@ -97,7 +97,7 @@ EXPORT unsigned char *make_hash(struct metafile *m)
 		   to the end of the file */
 		while (1) {
 			ssize_t d = read(fd, read_buf + r, m->piece_length - r);
-			FATAL_IF(d < 0, "Error reading from '%s': %s\n",
+			FATAL_IF(d < 0, "cannot read from '%s': %s\n",
 				f->path, strerror(errno));
 
 			if (d == 0) /* end of file */
@@ -118,7 +118,7 @@ EXPORT unsigned char *make_hash(struct metafile *m)
 		}
 
 		/* now close the file */
-		FATAL_IF(close(fd), "Error closing '%s': %s\n",
+		FATAL_IF(close(fd), "cannot close '%s': %s\n",
 			f->path, strerror(errno));
 	}
 
@@ -132,8 +132,8 @@ EXPORT unsigned char *make_hash(struct metafile *m)
 #ifndef NO_HASH_CHECK
 	counter += r;
 	FATAL_IF(counter != m->size,
-		"Counted %" PRId64 " bytes, but hashed %" PRId64 " bytes. "
-		"Something is wrong...\n",
+		"counted %" PRId64 " bytes, but hashed %" PRId64 " bytes; "
+		"something is wrong...\n",
 			m->size, counter);
 #endif
 

--- a/init.c
+++ b/init.c
@@ -83,7 +83,7 @@ static void set_absolute_file_path(struct metafile *m)
 	   using getcwd is a bit of a PITA */
 	/* allocate initial string */
 	string = malloc(length);
-	FATAL_IF0(string == NULL, "Out of memory.\n");
+	FATAL_IF0(string == NULL, "out of memory\n");
 	
 	/* while our allocated memory for the working dir isn't big enough */
 	while (getcwd(string, length) == NULL) {
@@ -93,7 +93,7 @@ static void set_absolute_file_path(struct metafile *m)
 		free(string);
 		/* and allocate a new one twice as big muahaha */
 		string = malloc(length);
-		FATAL_IF0(string == NULL, "Out of memory.\n");
+		FATAL_IF0(string == NULL, "out of memory\n");
 	}
 
 	/* now set length to the proper length of the working dir */
@@ -103,14 +103,14 @@ static void set_absolute_file_path(struct metafile *m)
 		/* append <torrent name>.torrent to the working dir */
 		string =
 		    realloc(string, length + strlen(m->torrent_name) + 10);
-		FATAL_IF0(string == NULL, "Out of memory.\n");
+		FATAL_IF0(string == NULL, "out of memory\n");
 		sprintf(string + length, DIRSEP "%s.torrent", m->torrent_name);
 	} else {
 		/* otherwise append the torrent path to the working dir */
 		string =
 		    realloc(string,
 			    length + strlen(m->metainfo_file_path) + 2);
-		FATAL_IF0(string == NULL, "Out of memory.\n");
+		FATAL_IF0(string == NULL, "out of memory\n");
 		sprintf(string + length, DIRSEP "%s", m->metainfo_file_path);
 	}
 
@@ -128,7 +128,7 @@ static slist_t *get_slist(char *s)
 
 	/* allocate memory for the first node in the list */
 	list = last = malloc(sizeof(slist_t));
-	FATAL_IF0(list == NULL, "Out of memory.\n");
+	FATAL_IF0(list == NULL, "out of memory\n");
 
 	/* add URLs to the list while there are commas in the string */
 	while ((e = strchr(s, ','))) {
@@ -143,7 +143,7 @@ static slist_t *get_slist(char *s)
 		/* append another node to the list */
 		last->next = malloc(sizeof(slist_t));
 		last = last->next;
-		FATAL_IF0(last == NULL, "Out of memory.\n");
+		FATAL_IF0(last == NULL, "out of memory\n");
 	}
 
 	/* set the last string in the list */
@@ -163,7 +163,7 @@ static int is_dir(struct metafile *m, char *target)
 	struct stat s;		/* stat structure for stat() to fill */
 
 	/* stat the target */
-	FATAL_IF(stat(target, &s), "Error stat'ing '%s': %s\n",
+	FATAL_IF(stat(target, &s), "cannot stat '%s': %s\n",
 		target, strerror(errno));
 
 	/* if it is a directory, just return 1 */
@@ -177,7 +177,7 @@ static int is_dir(struct metafile *m, char *target)
 	/* since we know the torrent is just a single file and we've
 	   already stat'ed it, we might as well set the file list */
 	m->file_list = malloc(sizeof(flist_t));
-	FATAL_IF0(m->file_list == NULL, "Out of memory.\n");
+	FATAL_IF0(m->file_list == NULL, "out of memory\n");
 	m->file_list->path = target;
 	m->file_list->size = s.st_size;
 	m->file_list->next = NULL;
@@ -229,7 +229,7 @@ static int process_node(const char *path, const struct stat *sb, void *data)
 	new_node = malloc(sizeof(flist_t));
 	if (new_node == NULL ||
 			(new_node->path = strdup(path)) == NULL) {
-		fprintf(stderr, "Out of memory.\n");
+		fprintf(stderr, "fatal error: out of memory\n");
 		return -1;
 	}
 	new_node->size = sb->st_size;
@@ -429,7 +429,7 @@ EXPORT void init(struct metafile *m, int argc, char *argv[])
 				announce_last = announce_last->next;
 
 			}
-			FATAL_IF0(announce_last == NULL, "Out of memory.\n");
+			FATAL_IF0(announce_last == NULL, "out of memory\n");
 			announce_last->l = get_slist(optarg);
 			break;
 		case 'c':
@@ -477,14 +477,14 @@ EXPORT void init(struct metafile *m, int argc, char *argv[])
 				web_seed_last = web_seed_last->next;
 			break;
 		case '?':
-			fatal("Use -h for help.\n");
+			fatal("use -h for help.\n");
 		}
 	}
 
 	/* set the correct piece length.
 	   default is 2^18 = 256kb. */
 	FATAL_IF0(m->piece_length < 15 || m->piece_length > 28,
-		"The piece length must be a number between 15 and 28.\n");
+		"the piece length must be a number between 15 and 28.\n");
 	m->piece_length = 1 << m->piece_length;
 
 	if (announce_last != NULL)
@@ -492,13 +492,13 @@ EXPORT void init(struct metafile *m, int argc, char *argv[])
 
 	/* ..and a file or directory from which to create the torrent */
 	FATAL_IF0(optind >= argc,
-		"Must specify the contents, use -h for help\n");
+		"must specify the contents, use -h for help\n");
 
 #ifdef USE_PTHREADS
 	/* check the number of threads */
 	if (m->threads) {
 		FATAL_IF0(m->threads > 20,
-			"The number of threads is limited to at most 20\n");
+			"the number of threads is limited to at most 20\n");
 	} else {
 #ifdef _SC_NPROCESSORS_ONLN
 		m->threads = sysconf(_SC_NPROCESSORS_ONLN);
@@ -527,7 +527,7 @@ EXPORT void init(struct metafile *m, int argc, char *argv[])
 	m->target_is_directory = is_dir(m, argv[optind]);
 	if (m->target_is_directory) {
 		/* change to the specified directory */
-		FATAL_IF(chdir(argv[optind]), "Error changing directory to '%s': %s\n",
+		FATAL_IF(chdir(argv[optind]), "cannot change directory to '%s': %s\n",
 			argv[optind], strerror(errno));
 
 		if (file_tree_walk("." DIRSEP, MAX_OPENFD, process_node, m))

--- a/main.c
+++ b/main.c
@@ -77,11 +77,11 @@ static FILE *open_file(const char *path)
 	/* open and create the file if it doesn't exist already */
 	fd = open(path, O_WRONLY | O_BINARY | O_CREAT | O_EXCL,
 		       S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-	FATAL_IF(fd < 0, "Error creating '%s': %s\n", path, strerror(errno));
+	FATAL_IF(fd < 0, "cannot create '%s': %s\n", path, strerror(errno));
 	
 	/* create the stream from this filedescriptor */
 	f = fdopen(fd, "wb");
-	FATAL_IF(f == NULL, "Error creating stream for '%s': %s\n",
+	FATAL_IF(f == NULL, "cannot create stream for '%s': %s\n",
 		path, strerror(errno));
 
 	return f;
@@ -93,7 +93,7 @@ static FILE *open_file(const char *path)
 static void close_file(FILE *f)
 {
 	/* close the metainfo file */
-	FATAL_IF(fclose(f), "Error closing stream: %s\n", strerror(errno));
+	FATAL_IF(fclose(f), "cannot close stream: %s\n", strerror(errno));
 }
 
 /*

--- a/main.c
+++ b/main.c
@@ -44,6 +44,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #endif
 
 #include "init.c"
+#include "msg.c"
 #include "output.c"
 
 #ifndef USE_OPENSSL

--- a/main.c
+++ b/main.c
@@ -30,6 +30,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "init.h"
 #include "hash.h"
 #include "output.h"
+#include "msg.h"
 
 #ifdef ALLINONE
 /* include all .c files in alphabetical order */
@@ -76,19 +77,12 @@ static FILE *open_file(const char *path)
 	/* open and create the file if it doesn't exist already */
 	fd = open(path, O_WRONLY | O_BINARY | O_CREAT | O_EXCL,
 		       S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-	if (fd < 0) {
-		fprintf(stderr, "Error creating '%s': %s\n",
-				path, strerror(errno));
-		exit(EXIT_FAILURE);
-	}
-
+	FATAL_IF(fd < 0, "Error creating '%s': %s\n", path, strerror(errno));
+	
 	/* create the stream from this filedescriptor */
 	f = fdopen(fd, "wb");
-	if (f == NULL) {
-		fprintf(stderr,	"Error creating stream for '%s': %s\n",
-				path, strerror(errno));
-		exit(EXIT_FAILURE);
-	}
+	FATAL_IF(f == NULL, "Error creating stream for '%s': %s\n",
+		path, strerror(errno));
 
 	return f;
 }
@@ -99,11 +93,7 @@ static FILE *open_file(const char *path)
 static void close_file(FILE *f)
 {
 	/* close the metainfo file */
-	if (fclose(f)) {
-		fprintf(stderr, "Error closing stream: %s\n",
-				strerror(errno));
-		exit(EXIT_FAILURE);
-	}
+	FATAL_IF(fclose(f), "Error closing stream: %s\n", strerror(errno));
 }
 
 /*

--- a/msg.c
+++ b/msg.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#include "msg.h"
+
+
+void fatal(const char *format, ...) {
+
+	va_list args;
+	va_start(args, format);
+	
+	fputs("fatal error: ", stderr);
+	vfprintf(stderr, format, args);
+	
+	va_end(args);
+	
+	exit(EXIT_FAILURE);
+}

--- a/msg.c
+++ b/msg.c
@@ -21,10 +21,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <stdlib.h>
 #include <stdarg.h>
 
+#include "export.h"
 #include "msg.h"
 
 
-void fatal(const char *format, ...)
+EXPORT void fatal(const char *format, ...)
 {
 
 	va_list args;

--- a/msg.c
+++ b/msg.c
@@ -24,7 +24,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "msg.h"
 
 
-void fatal(const char *format, ...) {
+void fatal(const char *format, ...)
+{
 
 	va_list args;
 	va_start(args, format);

--- a/msg.c
+++ b/msg.c
@@ -1,3 +1,22 @@
+/*
+This file is part of mktorrent
+
+mktorrent is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+mktorrent is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+*/
+
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/msg.h
+++ b/msg.h
@@ -1,0 +1,10 @@
+#ifndef MKTORRENT_MSG_H
+#define MKTORRENT_MSG_H
+
+void fatal(const char *format, ...);
+
+
+#define FATAL_IF(cond, format, ...) do { if (cond) fatal(format, __VA_ARGS__); } while(0)
+#define FATAL_IF0(cond, format) do { if (cond) fatal(format); } while(0)
+
+#endif /* MKTORRENT_MSG_H */

--- a/msg.h
+++ b/msg.h
@@ -1,7 +1,9 @@
 #ifndef MKTORRENT_MSG_H
 #define MKTORRENT_MSG_H
 
-void fatal(const char *format, ...);
+#include "export.h"
+
+EXPORT void fatal(const char *format, ...);
 
 
 #define FATAL_IF(cond, format, ...) do { if (cond) fatal(format, __VA_ARGS__); } while(0)


### PR DESCRIPTION
This pull requests introduces a new function (`fatal()`), and two macros (`FATAL_IF()`, and `FATAL_IF0()`) which can be used to (conditionally in the case of the macros) print a formatted error message that's prefixed with `fatal error: ` and exit the program with `EXIT_FAILURE` status code. The error messages have also been rewritten to some degree and converted to lower case.