### PR TITLE
Remove unnecessary whitespace in all files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Proper support for large files on certain 32bit OS's.
   Finally mktorrent properly handles files larger than 2Gb on 32bit Linux.
   Fixes for use on Windows under MinGW/Cygwin.
-  
+
 ## [0.6] - 2009-05-13
 ### Added
 - Support for multiple web seeds

--- a/hash.c
+++ b/hash.c
@@ -85,7 +85,7 @@ EXPORT unsigned char *make_hash(struct metafile *m)
 	/* go through all the files in the file list */
 	LL_FOR(file_node, m->file_list) {
 		struct file_data *f = LL_DATA_AS(file_node, struct file_data*);
-		
+
 		/* open the current file for reading */
 		FATAL_IF((fd = open(f->path, OPENFLAGS)) == -1,
 			"cannot open '%s' for reading: %s\n", f->path, strerror(errno));

--- a/hash_pthreads.c
+++ b/hash_pthreads.c
@@ -86,7 +86,7 @@ static struct piece *get_free(struct queue *q, size_t piece_length)
 	} else if (q->buffers < q->buffers_max) {
 		r = malloc(sizeof(struct piece) - 1 + piece_length);
 		FATAL_IF0(r == NULL, "out of memory\n");
-		
+
 
 		q->buffers++;
 	} else {

--- a/init.c
+++ b/init.c
@@ -91,7 +91,7 @@ static void set_absolute_file_path(struct metafile *m)
 	/* allocate initial string */
 	string = malloc(length);
 	FATAL_IF0(string == NULL, "out of memory\n");
-	
+
 	/* while our allocated memory for the working dir isn't big enough */
 	while (getcwd(string, length) == NULL) {
 		/* double the buffer size */
@@ -141,7 +141,7 @@ static struct ll *get_slist(char *s)
 		/* set the commas to \0 so the URLs appear as
 		 * separate strings */
 		*e = '\0';
-		
+
 		FATAL_IF0(ll_append(list, s, 0) == NULL, "out of memory\n");
 
 		/* move s to point to the next URL */
@@ -184,11 +184,11 @@ static int is_dir(struct metafile *m, char *target)
 		strdup(target),
 		(uintmax_t) s.st_size
 	};
-	
+
 	FATAL_IF0(
 		fd.path == NULL || ll_append(m->file_list, &fd, sizeof(fd)) == NULL,
 		"out of memory\n");
-	
+
 	/* ..and size variable */
 	m->size = (uintmax_t) s.st_size;
 
@@ -305,18 +305,18 @@ static void print_help()
 static void print_announce_list(struct ll *list)
 {
 	unsigned int tier = 1;
-	
+
 	LL_FOR(node, list) {
-		
-		struct ll *inner_list = LL_DATA(node);	
-		
+
+		struct ll *inner_list = LL_DATA(node);
+
 		printf("    %u : %s\n",
 			tier, LL_DATA_AS(LL_HEAD(inner_list), const char*));
-		
+
 		LL_FOR_FROM(inner_node, LL_NEXT(LL_HEAD(inner_list))) {
 			printf("        %s\n", LL_DATA_AS(inner_node, const char*));
 		}
-		
+
 		tier += 1;
 	}
 }
@@ -332,7 +332,7 @@ static void print_web_seed_list(struct ll *list)
 		printf("none\n");
 		return;
 	}
-	
+
 	printf("%s\n", LL_DATA_AS(LL_HEAD(list), const char*));
 	LL_FOR_FROM(node, LL_NEXT(LL_HEAD(list))) {
 		printf("                %s\n", LL_DATA_AS(node, const char*));
@@ -430,10 +430,10 @@ EXPORT void init(struct metafile *m, int argc, char *argv[])
 
 	m->announce_list = ll_new();
 	FATAL_IF0(m->announce_list == NULL, "out of memory\n");
-	
+
 	m->web_seed_list = ll_new();
 	FATAL_IF0(m->web_seed_list == NULL, "out of memory\n");
-	
+
 	m->file_list = ll_new();
 	FATAL_IF0(m->file_list == NULL, "out of memory\n");
 
@@ -545,7 +545,7 @@ EXPORT void init(struct metafile *m, int argc, char *argv[])
 		if (file_tree_walk("." DIRSEP, MAX_OPENFD, process_node, m))
 			exit(EXIT_FAILURE);
 	}
-	
+
 	ll_sort(m->file_list, file_data_cmp_by_name);
 
 	/* calculate the number of pieces
@@ -562,10 +562,10 @@ EXPORT void init(struct metafile *m, int argc, char *argv[])
 EXPORT void cleanup_metafile(struct metafile *m)
 {
 	ll_free(m->announce_list, free_inner_list);
-	
+
 	ll_free(m->file_list, file_data_clear);
-	
+
 	ll_free(m->web_seed_list, NULL);
-	
+
 	free(m->metainfo_file_path);
 }

--- a/ll.c
+++ b/ll.c
@@ -27,34 +27,34 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 EXPORT struct ll *ll_new(void)
 {
 	struct ll *list = calloc(1, sizeof(*list));
-	
+
 	if (list)
 		LL_TAIL(list) = &list->head;
-	
+
 	return list;
 }
 
 EXPORT void ll_free(struct ll *list, ll_node_data_destructor destructor)
 {
 	if (list) {
-		
+
 		struct ll_node *head = LL_HEAD(list), *next;
-		
+
 		while (head) {
-			
+
 			if (destructor)
 				destructor(LL_DATA(head));
-			
+
 			if (head->data_size)
 				free(LL_DATA(head));
-			
+
 			next = LL_NEXT(head);
-			
+
 			free(head);
-			
+
 			head = next;
 		}
-		
+
 		free(list);
 	}
 }
@@ -66,30 +66,30 @@ static struct ll_node *ll_node_new(
 	struct ll_node *next)
 {
 	struct ll_node *node = calloc(1, sizeof(*node));
-	
+
 	if (!node)
 		return NULL;
-	
+
 	if (data_size) {
 		LL_DATA(node) = calloc(1, data_size);
-		
+
 		if (!LL_DATA(node))
 			goto oom_node_data;
-		
+
 		memcpy(LL_DATA(node), data, data_size);
 	}
 	else
 		LL_DATA(node) = data;
-	
+
 	LL_DATASIZE(node) = data_size;
 	LL_PREV(node) = prev;
 	LL_NEXT(node) = next;
-	
+
 	return node;
-	
+
 oom_node_data:
 	free(node);
-	
+
 	return NULL;
 }
 
@@ -98,14 +98,14 @@ EXPORT struct ll_node *ll_append(struct ll *list, void *data, const size_t data_
 {
 	if (!list)
 		return NULL;
-		
+
 	struct ll_node *node = ll_node_new(data, data_size, LL_TAIL(list), NULL);
-	
+
 	if (node) {
 		LL_NEXT(LL_TAIL(list)) = node;
 		LL_TAIL(list) = node;
 	}
-	
+
 	return node;
 }
 
@@ -114,14 +114,14 @@ EXPORT struct ll *ll_extend(struct ll *list, struct ll *other)
 {
 	if (!list)
 		return NULL;
-		
+
 	if (!other)
 		return list;
 
 	LL_NEXT(LL_TAIL(list)) = LL_HEAD(other);
-	
+
 	free(other);
-	
+
 	return list;
 }
 
@@ -142,10 +142,10 @@ static void ll_sort_node_range(
 	LL_STEP(x); \
 	LL_STEP(t); \
 } while(0)
-	
+
 	if (first == NULL || *first == NULL || last == NULL || *last == NULL)
 		return;
-	
+
 	/* sorting a one element range is trivial */
 	if (*first == *last) {
 		LL_CLEAR_LINKS(*first);
@@ -153,50 +153,50 @@ static void ll_sort_node_range(
 	}
 
 	struct ll_node *middle = *first, *middle2 = *last;
-	
+
 	while (middle != middle2 && LL_NEXT(middle) != middle2) {
 		middle  = LL_NEXT(middle);
 		middle2 = LL_PREV(middle2);
 	}
-	
+
 	/* middle is now the midpoint of the list */
-	
+
 	/* 'tail' is the tail of the new, sorted list */
 	struct ll_node dummy, *tail = &dummy;
-	
+
 	struct ll_node *a = *first;
-	struct ll_node *b = LL_NEXT(middle); 
-	
+	struct ll_node *b = LL_NEXT(middle);
+
 	/* the values of middle and *last are not used anymore in this function,
 	 * so they can be safely overwritten by the recursive calls
 	 */
 	ll_sort_node_range(&a, &middle, cmp);
 	ll_sort_node_range(&b,    last, cmp);
-	
+
 	while (a && b) {
 		int r = cmp(LL_DATA(a), LL_DATA(b));
-	
+
 		if (r <= 0) APPEND_AND_STEP(tail, a); /* if a.val <= b.val, append a */
 		else        APPEND_AND_STEP(tail, b); /* otherwise,         append b */
 	}
-	
+
 	/* at this point only one of a or b might be non-NULL,
 	 * so only one of the next two loops will run
 	 */
-	
+
 	/* append remaining nodes from the first half */
 	while (a) APPEND_AND_STEP(tail, a);
-	
+
 	/* append remaining nodes from the second half */
 	while (b) APPEND_AND_STEP(tail, b);
-	
+
 	/* the prev ptr of the first "real" node points to dummy, clear that */
 	LL_PREV(LL_NEXT(&dummy)) = NULL;
-	
+
 	/* set the new head and tail */
 	*first = LL_NEXT(&dummy);
 	*last = tail;
-	
+
 #undef APPEND_AND_STEP
 }
 
@@ -204,11 +204,11 @@ EXPORT struct ll *ll_sort(struct ll *list, ll_node_data_cmp cmp)
 {
 	if (list == NULL || cmp == NULL)
 		return NULL;
-	
+
 	ll_sort_node_range(&LL_HEAD(list), &LL_TAIL(list), cmp);
-	
+
 	if (LL_HEAD(list))
 		LL_PREV(LL_HEAD(list)) = &list->head;
-	
-	return list;	
+
+	return list;
 }

--- a/ll.h
+++ b/ll.h
@@ -3,7 +3,7 @@
 
 struct ll_node {
     struct ll_node *prev, *next;
-    
+
     size_t data_size;
     void *data;
 };
@@ -44,7 +44,7 @@ EXPORT struct ll *ll_new(void);
 EXPORT void ll_free(struct ll *, ll_node_data_destructor);
 
 
-/* appends a new node with data to the end of the given list, 
+/* appends a new node with data to the end of the given list,
  * if the provided size is zero, then the data pointer is set to
  * the pointer provided in the arguments, otherwise size number of
  * "bytes" is allocated, and that amount of bytes is copied into

--- a/main.c
+++ b/main.c
@@ -81,7 +81,7 @@ static FILE *open_file(const char *path)
 	fd = open(path, O_WRONLY | O_BINARY | O_CREAT | O_EXCL,
 		       S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 	FATAL_IF(fd < 0, "cannot create '%s': %s\n", path, strerror(errno));
-	
+
 	/* create the stream from this filedescriptor */
 	f = fdopen(fd, "wb");
 	FATAL_IF(f == NULL, "cannot create stream for '%s': %s\n",
@@ -143,10 +143,10 @@ int main(int argc, char *argv[])
 
 	/* and write the metainfo to file */
 	write_metainfo(file, &m, hash);
-	
+
 	/* close the file stream */
 	close_file(file);
-	
+
 	/* free allocated memory */
 	cleanup_metafile(&m);
 	free(hash);

--- a/msg.c
+++ b/msg.c
@@ -30,11 +30,11 @@ EXPORT void fatal(const char *format, ...)
 
 	va_list args;
 	va_start(args, format);
-	
+
 	fputs("fatal error: ", stderr);
 	vfprintf(stderr, format, args);
-	
+
 	va_end(args);
-	
+
 	exit(EXIT_FAILURE);
 }

--- a/output.c
+++ b/output.c
@@ -47,16 +47,16 @@ static void write_announce_list(FILE *f, struct ll *list)
 
 		/* .. and print the lists */
 		fprintf(f, "l");
-		
+
 		LL_FOR(announce_url_node, LL_DATA_AS(tier_node, struct ll*)) {
-			
+
 			const char *announce_url =
 				LL_DATA_AS(announce_url_node, const char*);
-		
+
 			fprintf(f, "%lu:%s",
 					(unsigned long) strlen(announce_url), announce_url);
 		}
-			
+
 		fprintf(f, "e");
 	}
 	fprintf(f, "e");
@@ -74,7 +74,7 @@ static void write_file_list(FILE *f, struct ll *list)
 	/* go through all the files */
 	LL_FOR(file_node, list) {
 		struct file_data *fd = LL_DATA_AS(file_node, struct file_data*);
-	
+
 		/* the file list contains a dictionary for every file
 		   with entries for the length and path
 		   write the length first */
@@ -117,7 +117,7 @@ static void write_web_seed_list(FILE *f, struct ll *list)
 		const char *web_seed_url = LL_DATA_AS(node, const char*);
 		fprintf(f, "%lu:%s",
 			(unsigned long) strlen(web_seed_url), web_seed_url);
-	} 
+	}
 	/* end the list */
 	fprintf(f, "e");
 }
@@ -136,17 +136,17 @@ EXPORT void write_metainfo(FILE *f, struct metafile *m, unsigned char *hash_stri
 	fprintf(f, "d");
 
 	if (!LL_IS_EMPTY(m->announce_list)) {
-	
+
 		struct ll *first_tier =
 			LL_DATA_AS(LL_HEAD(m->announce_list), struct ll*);
-			
+
 		/* write the announce URL */
 		const char *first_announce_url
 			= LL_DATA_AS(LL_HEAD(first_tier), const char*);
-		
+
 		fprintf(f, "8:announce%lu:%s",
 			(unsigned long) strlen(first_announce_url), first_announce_url);
-			
+
 		/* write the announce-list entry if we have
 		 * more than one announce URL, namely
 		 * a) there are at least two tiers, or      (first part of OR)
@@ -202,7 +202,7 @@ EXPORT void write_metainfo(FILE *f, struct metafile *m, unsigned char *hash_stri
 		if (LL_IS_SINGLETON(m->web_seed_list)) {
 			const char *first_web_seed =
 				LL_DATA_AS(LL_HEAD(m->web_seed_list), const char*);
-				
+
 			fprintf(f, "8:url-list%lu:%s",
 					(unsigned long) strlen(first_web_seed), first_web_seed);
 		} else


### PR DESCRIPTION
My editor automatically removes extra whitespace such as this every time it writes a file, so some of these changes were getting grouped in with other commits I am working on. I think it would be good to just remove all of this now to save some trouble for myself and others in this situation.