### PR TITLE
Add flag to enable easier cross-seeding

### DIFF
--- a/init.c
+++ b/init.c
@@ -274,6 +274,7 @@ static void print_help()
 	  "-v, --verbose                 : be verbose\n"
 	  "-w, --web-seed=<url>[,<url>]* : add web seed URLs\n"
 	  "                                additional -w adds more URLs\n"
+	  "-x, --cross-seed              : ensure info hash is unique for easier cross-seeding\n"
 #else
 	  "-a <url>[,<url>]* : specify the full announce URLs\n"
 	  "                    additional -a adds backup trackers\n"
@@ -296,6 +297,7 @@ static void print_help()
 	  "-v                : be verbose\n"
 	  "-w <url>[,<url>]* : add web seed URLs\n"
 	  "                    additional -w adds more URLs\n"
+	  "-x                : ensure info hash is unique for easier cross-seeding\n"
 #endif
 	  "\nPlease send bug reports, patches, feature requests, praise and\n"
 	  "general gossip about the program to: mktorrent@rudde.org\n");
@@ -427,6 +429,7 @@ EXPORT void init(struct metafile *m, int argc, char *argv[])
 #endif
 		{"verbose", 0, NULL, 'v'},
 		{"web-seed", 1, NULL, 'w'},
+		{"cross-seed", 0, NULL, 'x'},
 		{NULL, 0, NULL, 0}
 	};
 #endif
@@ -442,9 +445,9 @@ EXPORT void init(struct metafile *m, int argc, char *argv[])
 
 	/* now parse the command line options given */
 #ifdef USE_PTHREADS
-#define OPT_STRING "a:c:dfhl:n:o:ps:t:vw:"
+#define OPT_STRING "a:c:dfhl:n:o:ps:t:vw:x"
 #else
-#define OPT_STRING "a:c:dfhl:n:o:ps:vw:"
+#define OPT_STRING "a:c:dfhl:n:o:ps:vw:x"
 #endif
 #ifdef USE_LONG_OPTIONS
 	while ((c = getopt_long(argc, argv, OPT_STRING,
@@ -496,6 +499,9 @@ EXPORT void init(struct metafile *m, int argc, char *argv[])
 			break;
 		case 'w':
 			ll_extend(m->web_seed_list, get_slist(optarg));
+			break;
+		case 'x':
+			m->cross_seed = 1;
 			break;
 		case '?':
 			fatal("use -h for help.\n");

--- a/main.c
+++ b/main.c
@@ -18,12 +18,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 */
 
 
-#include <stdlib.h>      /* exit() */
+#include <stdlib.h>      /* exit(), srandom() */
 #include <errno.h>       /* errno */
 #include <string.h>      /* strerror() */
 #include <stdio.h>       /* printf() etc. */
 #include <sys/stat.h>    /* S_IRUSR, S_IWUSR, S_IRGRP, S_IROTH */
 #include <fcntl.h>       /* open() */
+#include <time.h>        /* clock_gettime() */
 
 #include "export.h"
 #include "mktorrent.h"
@@ -121,6 +122,7 @@ int main(int argc, char *argv[])
 		0,    /* no_creation_date */
 		0,    /* private */
 		NULL, /* source string */
+		0,    /* cross_seed */
 		0,    /* verbose */
 		0,    /* force_overwrite */
 #ifdef USE_PTHREADS
@@ -135,6 +137,12 @@ int main(int argc, char *argv[])
 
 	/* print who we are */
 	printf("mktorrent " VERSION " (c) 2007, 2009 Emil Renner Berthing\n\n");
+
+	/* seed PRNG with current time */
+	struct timespec ts;
+	FATAL_IF(clock_gettime(CLOCK_REALTIME, &ts) == -1,
+		"failed to get time: %s\n", strerror(errno));
+	srandom(ts.tv_nsec ^ ts.tv_sec);
 
 	/* process options */
 	init(&m, argc, argv);

--- a/mktorrent.h
+++ b/mktorrent.h
@@ -31,6 +31,7 @@ struct metafile {
 	int no_creation_date;      /* don't write the creation date */
 	int private;               /* set the private flag */
 	char *source;              /* set source for private trackers */
+	int cross_seed;            /* ensure info hash is unique for easier cross-seeding */
 	int verbose;               /* be verbose */
 	int force_overwrite;       /* overwrite existing output file */
 #ifdef USE_PTHREADS

--- a/output.c
+++ b/output.c
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <string.h>       /* strlen() etc. */
 #include <time.h>         /* time() */
 #include <inttypes.h>     /* PRIuMAX */
+#include <stdlib.h>       /* random() */
 
 #ifdef USE_OPENSSL
 #include <openssl/sha.h>  /* SHA_DIGEST_LENGTH */
@@ -178,6 +179,15 @@ EXPORT void write_metainfo(FILE *f, struct metafile *m, unsigned char *hash_stri
 			LL_DATA_AS(LL_HEAD(m->file_list), struct file_data*)->size);
 	else
 		write_file_list(f, m->file_list);
+
+	if (m->cross_seed) {
+		fprintf(f, "12:x_cross_seed%u:mktorrent-", CROSS_SEED_RAND_LENGTH * 2 + 10);
+		for (int i = 0; i < CROSS_SEED_RAND_LENGTH; i++) {
+			unsigned char rand_byte = random();
+			fputc("0123456789ABCDEF"[rand_byte >> 4], f);
+			fputc("0123456789ABCDEF"[rand_byte & 0x0F], f);
+		}
+	}
 
 	/* the info section also contains the name of the torrent,
 	   the piece length and the hash string */

--- a/output.h
+++ b/output.h
@@ -6,6 +6,8 @@
 #include "export.h"     /* EXPORT */
 #include "mktorrent.h"  /* struct metafile */
 
+#define CROSS_SEED_RAND_LENGTH 16
+
 EXPORT void write_metainfo(FILE *f, struct metafile *m,
 			unsigned char *hash_string);
 


### PR DESCRIPTION
I don't know if this is within the scope of the project, but it is something that I've found to be very useful and I think others may find it useful, too. 

I recently ran into a problem when I wanted to cross seed the same files with two different torrents. Since the both torrent files used the same piece size and were operating on the same files, the generated info hashes were identical and my torrent client refused to add the second torrent. This flag prevents that from happening by adding a random entry like this to the info section of the torrent file:

`x_cross_seed42:mktorrent-EAB9AF9C87121A01849725228398D350e`

The only effect this entry should have is ensuring that the computed info hashes for two torrent files are different even if they have the same files and piece size. It should be ignored otherwise. This behavior can also be found in other popular programs such as [ruTorrent](https://github.com/Novik/ruTorrent/blob/f100be61ce9dda385e4854cc680016d127fcdd60/php/addtorrent.php#L116-L117) and [pyrocore](https://github.com/pyroscope/pyrocore/blob/8d0bf6e921ca53daa7874d54de32497e6d50a69b/src/pyrocore/scripts/mktor.py#L152-L161).