### PR TITLE
linked list: fix ll_extend bug

### DIFF
--- a/ll.c
+++ b/ll.c
@@ -118,7 +118,12 @@ EXPORT struct ll *ll_extend(struct ll *list, struct ll *other)
 	if (!other)
 		return list;
 
-	LL_NEXT(LL_TAIL(list)) = LL_HEAD(other);
+	if (!LL_IS_EMPTY(other)) {
+		LL_NEXT(LL_TAIL(list)) = LL_HEAD(other);
+		LL_PREV(LL_HEAD(other)) = LL_TAIL(list);
+		LL_TAIL(list) = LL_TAIL(other);
+	}
+
 
 	free(other);
 


### PR DESCRIPTION
This PR fixes a serious bug that caused multiple `-w` options not to work correctly. For example, `mktorrent -w 1,2,3 -w 4,5,6 ...` created a bittorrent file in which only 4,5,6 are stored in `url-list`.